### PR TITLE
🐛 fix: CSSの競合を修正

### DIFF
--- a/assets/css/terms.css
+++ b/assets/css/terms.css
@@ -1,3 +1,7 @@
 .terms {
   max-width: 800px;
 }
+
+ul {
+  list-style: disc;
+}


### PR DESCRIPTION
# 実施内容
- #53 でCSSのレビュー漏れがあり、list-styleがnoneになってしまっていたのでdiscに修正した。